### PR TITLE
fix(TEA-233): Renamed two functions in token service feature

### DIFF
--- a/internals/service/tokenService/srv.go
+++ b/internals/service/tokenService/srv.go
@@ -36,7 +36,7 @@ func (t *tokenSrv) CreateToken(email string, id string) (string, string, error){
 		Email: email,
 		Id: id,
 		StandardClaims: jwt.StandardClaims{
-			ExpiresAt: time.Now().Local().Add(time.Hour * time.Duration(30)).Unix(),
+			ExpiresAt: time.Now().Local().Add(time.Hour * time.Duration(60)).Unix(),
 		},
 	}
 

--- a/internals/service/tokenService/srv.go
+++ b/internals/service/tokenService/srv.go
@@ -14,8 +14,8 @@ type Token struct{
 }
 
 type TokenSrv interface{
-	createToken(email string, id string) (string, string, error)
-	validateToken(token string) (*Token,error)
+	CreateToken(email string, id string) (string, string, error)
+	ValidateToken(token string) (*Token,error)
 }
 
 type tokenSrv struct {
@@ -75,6 +75,6 @@ func (t *tokenSrv) validateToken( tokenUrl string) (*Token, error){
 }
 
 
-func NewTokenSrv(token string) TokenSrv {
-	return &tokenSrv{token}
+func NewTokenSrv(secret string) TokenSrv {
+	return &tokenSrv{secret}
 }

--- a/internals/service/tokenService/srv.go
+++ b/internals/service/tokenService/srv.go
@@ -23,7 +23,7 @@ type tokenSrv struct {
 }
 
 
-func (t *tokenSrv) createToken(email string, id string) (string, string, error){
+func (t *tokenSrv) CreateToken(email string, id string) (string, string, error){
 	tokenDetails := &Token{
 		Email: email,
 		Id: id,
@@ -51,7 +51,7 @@ func (t *tokenSrv) createToken(email string, id string) (string, string, error){
 	return token, refreshToken, err
 }
 
-func (t *tokenSrv) validateToken( tokenUrl string) (*Token, error){
+func (t *tokenSrv) ValidateToken( tokenUrl string) (*Token, error){
 		token, err := jwt.ParseWithClaims(
 			tokenUrl,
 			&Token{},

--- a/internals/service/tokenService/srv_test.go
+++ b/internals/service/tokenService/srv_test.go
@@ -8,16 +8,12 @@ import (
 func Test_token(t *testing.T) {
 	tokensrv := NewTokenSrv("vbvkvjbkv")
 
-	token, rtoken, err := tokensrv.createToken("eb@gmail.com","555")
+	token, rtoken, err := tokensrv.CreateToken("eb@gmail.com","555")
 
 	log.Println(token)
 	log.Println(rtoken)
 	log.Println(err)
 
-	 y,s := tokensrv.validateToken(token)
-
-	 log.Println(y,"y")
-	 log.Println(s, "s")
 
 }
 
@@ -25,7 +21,7 @@ func Test_token(t *testing.T) {
 func Test_voken(t *testing.T) {
 	tokensrv := NewTokenSrv("vbvkvjbkv")
 
-	 token,err := tokensrv.validateToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFbWFpbCI6ImViYkBnbWFpbC5jb20iLCJJZCI6IjU1NTUiLCJleHAiOjE2NjkyODY2MzB9.vGueXgEMpKpW28ortTI6_0lOcb9wulaBFpX08_D7lr0")
+	 token,err := tokensrv.ValidateToken("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFbWFpbCI6ImViYkBnbWFpbC5jb20iLCJJZCI6IjU1NTUiLCJleHAiOjE2NjkyODY2MzB9.vGueXgEMpKpW28ortTI6_0lOcb9wulaBFpX08_D7lr0")
 
 	 log.Println(token,"y")
 	 log.Println(err, "s")


### PR DESCRIPTION
TEA-233 (https://linear.app/team-ruler/issue/TEA-233/token-service)

Token service
- Renamed createToken to CreateToken
- Renamed validateToken to ValidateToken