### PR TITLE
Feat(TEA - 234) :middleware

### DIFF
--- a/cmd/middlewares/validateJWTMiddleware.go
+++ b/cmd/middlewares/validateJWTMiddleware.go
@@ -1,0 +1,30 @@
+package middlewares
+
+import (
+	"log"
+	"net/http"
+	tokenservice "test-va/internals/service/tokenService"
+
+	"github.com/gin-gonic/gin"
+)
+
+func ValidateJWT() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tokenSrv :=  tokenservice.NewTokenSrv("tokenString")
+
+		const BEARER_HEADER = "Bearer "
+		authHeader := c.GetHeader("Authorization")
+		tokenString := authHeader[len(BEARER_HEADER):]
+
+		token, err :=tokenSrv.ValidateToken(tokenString)
+
+		if err != nil {
+			c.Set("userId", token.Id)
+			c.Next()
+		}
+
+		log.Println(err)
+		c.AbortWithStatus(http.StatusUnauthorized)
+
+	}
+}

--- a/internals/service/reminderService/srv_test.go
+++ b/internals/service/reminderService/srv_test.go
@@ -2,13 +2,14 @@ package reminderService
 
 import (
 	"fmt"
-	"github.com/go-co-op/gocron"
 	"log"
 	"os"
 	"test-va/internals/Repository/taskRepo/mySqlRepo"
 	"test-va/internals/data-store/mysql"
 	"testing"
 	"time"
+
+	"github.com/go-co-op/gocron"
 )
 
 func Test_reminderSrv_SetReminder(t *testing.T) {
@@ -28,8 +29,8 @@ func Test_reminderSrv_SetReminder(t *testing.T) {
 	conn := connection.GetConn()
 	repo := mySqlRepo.NewSqlRepo(conn)
 
-	//gcrn := gocron.NewScheduler(time.UTC)
-	srv := NewReminderSrv(conn, repo)
+	gcrn := gocron.NewScheduler(time.UTC)
+	srv := NewReminderSrv(gcrn, conn, repo)
 	due := time.Now().Add(15 * time.Second).Format(time.RFC3339)
 	srv.SetReminder(due, taskId)
 


### PR DESCRIPTION
[Link to Linear ](https://linear.app/team-ruler/issue/TEA-234/middleware)

- This PR adds a middleware to the code base that can be used to verify every incoming request to the server.
- In the Function, the Bearer token would be extracted from the authorization Header of the request.
- The middleware calls the Validate Token function in the token service.
- if an error is returned from the function, the request is aborted with an un authorized status code.
- If there is no error, the request's User ID is added to the context with key "userId".
- the userId can be extracted from context and used to continue the request.

The middleware function can easily be called using ValidateJWT() function.