### PR TITLE
Feat/tea 234 middleware

### DIFF
--- a/cmd/middlewares/validateJWTMiddleware.go
+++ b/cmd/middlewares/validateJWTMiddleware.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"test-va/internals/entity/ResponseEntity"
 	tokenservice "test-va/internals/service/tokenService"
 
 	"github.com/gin-gonic/gin"
@@ -16,10 +17,6 @@ func ValidateJWT() gin.HandlerFunc {
 		// const BEARER_HEADER = "Bearer "
 		authHeader := c.GetHeader("Authorization")
 		auth := strings.Split(authHeader, " ")
-		if len(auth) < 2 {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, "Invalid Token")
-			return
-		}
 
 		token, err := tokenSrv.ValidateToken(auth[1])
 
@@ -31,6 +28,36 @@ func ValidateJWT() gin.HandlerFunc {
 
 		c.Set("userId", token.Id)
 		log.Println("middleware passed")
+		c.Next()
+	}
+}
+
+func CheckUserID() gin.HandlerFunc{
+	return func(ctx *gin.Context) {
+
+	}
+}
+
+func MapID() gin.HandlerFunc{
+	return func(c *gin.Context) {
+		userSession := c.GetString("userId")
+		userURL := c.Param("user_id")
+
+		if userSession == ""{
+			c.AbortWithStatusJSON(http.StatusBadRequest, ResponseEntity.BuildErrorResponse(http.StatusBadRequest, "Invalid UserID", nil, nil))
+			return
+		}
+
+		if userURL == ""{
+			c.AbortWithStatusJSON(http.StatusBadRequest, ResponseEntity.BuildErrorResponse(http.StatusBadRequest, "Invalid url", nil, nil))
+			return
+		}
+
+		if userSession != userURL {
+			c.AbortWithStatusJSON(http.StatusBadRequest, ResponseEntity.BuildErrorResponse(http.StatusBadRequest, "You are not allowed to modify resource", nil, nil))
+			return
+		}
+
 		c.Next()
 	}
 }


### PR DESCRIPTION
[Link to Linear](https://linear.app/team-ruler/issue/TEA-234/middleware)

This PR adds a MapID middleware to the code base that can be used to confirm  user IDs
In the Function, the Bearer token would be extracted from the authorization Header of the request.
